### PR TITLE
Fixed policies after renaming ideagroups

### DIFF
--- a/common/policies/00_adm.txt
+++ b/common/policies/00_adm.txt
@@ -29,16 +29,16 @@ agricultural_cultivations = {
 
 	potential = {
 		has_idea_group = economic_ideas
-		has_idea_group = quantity_ideas
+		has_idea_group = boarding_ideas
 		OR = {
 			full_idea_group = economic_ideas
-			full_idea_group = quantity_ideas
+			full_idea_group = boarding_ideas
 		}
 	}
 
 	allow = {
 		full_idea_group = economic_ideas
-		full_idea_group = quantity_ideas
+		full_idea_group = boarding_ideas
 	}		
 
 	allowed_marine_fraction = 0.1
@@ -75,16 +75,16 @@ formalized_measures = {
 
 
 	potential = {
-		has_idea_group = plutocracy_ideas
+		has_idea_group = charge_ideas
 		has_idea_group = economic_ideas
 		OR = {
-			full_idea_group = plutocracy_ideas
+			full_idea_group = charge_ideas
 			full_idea_group = economic_ideas
 		}
 	}
 
 	allow = {
-		full_idea_group = plutocracy_ideas
+		full_idea_group = charge_ideas
 		full_idea_group = economic_ideas
 	}
 
@@ -128,16 +128,16 @@ technological_pursuits_act = {
 
 	potential = {
 		has_idea_group = innovativeness_ideas
-		has_idea_group = spy_ideas
+		has_idea_group = campaign_ideas
 		OR = {
 			full_idea_group = innovativeness_ideas
-			full_idea_group = spy_ideas
+			full_idea_group = campaign_ideas
 		}
 	}
 	
 	allow = {
 		full_idea_group = innovativeness_ideas
-		full_idea_group = spy_ideas
+		full_idea_group = campaign_ideas
 	}
 
 	war_exhaustion_cost = -0.33
@@ -282,16 +282,16 @@ land_inheritance_act = {
 
 	potential = {
 		has_idea_group = administrative_ideas
-		has_idea_group = plutocracy_ideas
+		has_idea_group = charge_ideas
 		OR = {
 			full_idea_group = administrative_ideas
-			full_idea_group = plutocracy_ideas
+			full_idea_group = charge_ideas
 		}
 	}
 	
 	allow = {
 		full_idea_group = administrative_ideas
-		full_idea_group = plutocracy_ideas
+		full_idea_group = charge_ideas
 	}
 
 	war_exhaustion = -0.03
@@ -387,16 +387,16 @@ the_education_act = {
 
 	potential = {
 		has_idea_group = innovativeness_ideas
-		has_idea_group = plutocracy_ideas
+		has_idea_group = charge_ideas
 		OR = {
 			full_idea_group = innovativeness_ideas
-			full_idea_group = plutocracy_ideas
+			full_idea_group = charge_ideas
 		}
 	}
 	
 	allow = {
 		full_idea_group = innovativeness_ideas
-		full_idea_group = plutocracy_ideas
+		full_idea_group = charge_ideas
 	}
 
 	reinforce_cost_modifier = -0.33
@@ -505,16 +505,16 @@ cultural_recognition_act = {
 	
 	potential = {
 		has_idea_group = humanist_ideas
-		has_idea_group = plutocracy_ideas
+		has_idea_group = charge_ideas
 		OR = {
 			full_idea_group = humanist_ideas
-			full_idea_group = plutocracy_ideas
+			full_idea_group = charge_ideas
 		}
 	}
 	
 	allow = {
 		full_idea_group = humanist_ideas
-		full_idea_group = plutocracy_ideas
+		full_idea_group = charge_ideas
 	}	
 
 	production_efficiency = 0.1
@@ -831,16 +831,16 @@ industrial_transport = {
 	
 	potential = {
 		has_idea_group = humanist_ideas
-		has_idea_group = quality_ideas
+		has_idea_group = broadside_ideas
 		OR = {
 			full_idea_group = humanist_ideas
-			full_idea_group = quality_ideas
+			full_idea_group = broadside_ideas
 		}
 	}
 	
 	allow = {
 		full_idea_group = humanist_ideas
-		full_idea_group = quality_ideas
+		full_idea_group = broadside_ideas
 	}	
 	
 	ship_durability = 0.05

--- a/common/policies/00_dip.txt
+++ b/common/policies/00_dip.txt
@@ -381,16 +381,16 @@ cloth_quality_edict = {
 	monarch_power = DIP
 	potential = {
 		has_idea_group = trade_ideas
-		has_idea_group = quality_ideas
+		has_idea_group = broadside_ideas
 		OR = {
 			full_idea_group = trade_ideas
-			full_idea_group = quality_ideas
+			full_idea_group = broadside_ideas
 		}
 	}
 	
 	allow = {
 		full_idea_group = trade_ideas
-		full_idea_group = quality_ideas
+		full_idea_group = broadside_ideas
 	}
 
 	global_ship_recruit_speed = -0.2
@@ -425,16 +425,16 @@ production_quota_act = {
 	monarch_power = DIP
 	potential = {
 		has_idea_group = trade_ideas
-		has_idea_group = quantity_ideas
+		has_idea_group = boarding_ideas
 		OR = {
 			full_idea_group = trade_ideas
-			full_idea_group = quantity_ideas
+			full_idea_group = boarding_ideas
 		}
 	}
 	
 	allow = {
 		full_idea_group = trade_ideas
-		full_idea_group = quantity_ideas
+		full_idea_group = boarding_ideas
 	}
 
 	blockade_efficiency = 0.2
@@ -448,16 +448,16 @@ production_quota_act = {
 trade_kontor_network = {
 	monarch_power = DIP
 	potential = {
-		has_idea_group = plutocracy_ideas
+		has_idea_group = charge_ideas
 		has_idea_group = trade_ideas
 		OR = {
-			full_idea_group = plutocracy_ideas
+			full_idea_group = charge_ideas
 			full_idea_group = trade_ideas
 		}
 	}
 	
 	allow = {
-		full_idea_group = plutocracy_ideas
+		full_idea_group = charge_ideas
 		full_idea_group = trade_ideas
 	}
 	
@@ -493,16 +493,16 @@ policy_of_neutrality = {
 	monarch_power = DIP
 	potential = {
 		has_idea_group = diplomatic_ideas
-		has_idea_group = plutocracy_ideas
+		has_idea_group = charge_ideas
 		OR = {
 			full_idea_group = diplomatic_ideas
-			full_idea_group = plutocracy_ideas
+			full_idea_group = charge_ideas
 		}
 	}
 	
 	allow = {
 		full_idea_group = diplomatic_ideas
-		full_idea_group = plutocracy_ideas
+		full_idea_group = charge_ideas
 	}
 	
 	free_leader_pool = 2
@@ -517,16 +517,16 @@ professional_diplomatic_corps = {
 	monarch_power = DIP
 	potential = {
 		has_idea_group = diplomatic_ideas
-		has_idea_group = quality_ideas
+		has_idea_group = broadside_ideas
 		OR = {
 			full_idea_group = diplomatic_ideas
-			full_idea_group = quality_ideas
+			full_idea_group = broadside_ideas
 		}
 	}
 	
 	allow = {
 		full_idea_group = diplomatic_ideas
-		full_idea_group = quality_ideas
+		full_idea_group = broadside_ideas
 	}
 	
 	special_unit_forcelimit = 0.05
@@ -542,16 +542,16 @@ colonial_companies_act = {
 	monarch_power = DIP
 	potential = {
 		has_idea_group = exploration_ideas
-		has_idea_group = plutocracy_ideas
+		has_idea_group = charge_ideas
 		OR = {
 			full_idea_group = exploration_ideas
-			full_idea_group = plutocracy_ideas
+			full_idea_group = charge_ideas
 		}
 	}
 	
 	allow = {
 		full_idea_group = exploration_ideas
-		full_idea_group = plutocracy_ideas
+		full_idea_group = charge_ideas
 	}
 
 	global_trade_goods_size_modifier = 0.05
@@ -679,16 +679,16 @@ skilled_cartographers = {
 	monarch_power = DIP
 	
 	potential = {
-		has_idea_group = spy_ideas
+		has_idea_group = campaign_ideas
 		has_idea_group = exploration_ideas
 		OR = {
-			full_idea_group = spy_ideas
+			full_idea_group = campaign_ideas
 			full_idea_group = exploration_ideas
 		}
 	}
 	
 	allow = {
-		full_idea_group = spy_ideas
+		full_idea_group = campaign_ideas
 		full_idea_group = exploration_ideas
 	}	
 	
@@ -712,16 +712,16 @@ fortified_trading_posts = {
 	monarch_power = DIP
 	
 	potential = {
-		has_idea_group = spy_ideas
+		has_idea_group = campaign_ideas
 		has_idea_group = trade_ideas
 		OR = {
-			full_idea_group = spy_ideas
+			full_idea_group = campaign_ideas
 			full_idea_group = trade_ideas
 		}
 	}
 	
 	allow = {
-		full_idea_group = spy_ideas
+		full_idea_group = campaign_ideas
 		full_idea_group = trade_ideas
 	}	
 	
@@ -757,16 +757,16 @@ full_sovereignty_act = {
 	monarch_power = DIP
 	
 	potential = {
-		has_idea_group = plutocracy_ideas
+		has_idea_group = charge_ideas
 		has_idea_group = influence_ideas
 		OR = {
-			full_idea_group = plutocracy_ideas
+			full_idea_group = charge_ideas
 			full_idea_group = influence_ideas
 		}
 	}
 	
 	allow = {
-		full_idea_group = plutocracy_ideas
+		full_idea_group = charge_ideas
 		full_idea_group = influence_ideas
 	}	
 	
@@ -806,16 +806,16 @@ deserteur_act = {
 
 
 	potential = {
-		has_idea_group = spy_ideas
+		has_idea_group = campaign_ideas
 		has_idea_group = influence_ideas
 		OR = {
-			full_idea_group = spy_ideas
+			full_idea_group = campaign_ideas
 			full_idea_group = influence_ideas
 		}
 	}
 	
 	allow = {
-		full_idea_group = spy_ideas
+		full_idea_group = campaign_ideas
 		full_idea_group = influence_ideas
 	}
 
@@ -847,16 +847,16 @@ overseas_embassies = {
 	monarch_power = DIP
 	
 	potential = {
-		has_idea_group = spy_ideas
+		has_idea_group = campaign_ideas
 		has_idea_group = diplomatic_ideas
 		OR = {
-			full_idea_group = spy_ideas
+			full_idea_group = campaign_ideas
 			full_idea_group = diplomatic_ideas
 		}
 	}
 	
 	allow = {
-		full_idea_group = spy_ideas
+		full_idea_group = campaign_ideas
 		full_idea_group = diplomatic_ideas
 	}	
 	

--- a/common/policies/00_mil.txt
+++ b/common/policies/00_mil.txt
@@ -3,16 +3,16 @@ the_foreign_support_act = {
 
 
 	potential = {
-		has_idea_group = spy_ideas
+		has_idea_group = campaign_ideas
 		has_idea_group = economic_ideas
 		OR = {
-			full_idea_group = spy_ideas
+			full_idea_group = campaign_ideas
 			full_idea_group = economic_ideas
 		}
 	}
 	
 	allow = {
-		full_idea_group = spy_ideas
+		full_idea_group = campaign_ideas
 		full_idea_group = economic_ideas
 	}
 
@@ -29,16 +29,16 @@ the_royal_commission_act = {
 
 
 	potential = {
-		has_idea_group = spy_ideas
+		has_idea_group = campaign_ideas
 		has_idea_group = administrative_ideas
 		OR = {
-			full_idea_group = spy_ideas
+			full_idea_group = campaign_ideas
 			full_idea_group = administrative_ideas
 		}
 	}
 	
 	allow = {
-		full_idea_group = spy_ideas
+		full_idea_group = campaign_ideas
 		full_idea_group = administrative_ideas
 	}
 
@@ -55,15 +55,15 @@ weapon_quality_standards = {
 	
 	potential = {
 		has_idea_group = economic_ideas
-		has_idea_group = quality_ideas
+		has_idea_group = broadside_ideas
 		OR = {
 			full_idea_group = economic_ideas
-			full_idea_group = quality_ideas
+			full_idea_group = broadside_ideas
 		}	
 	}
 	allow = {
 		full_idea_group = economic_ideas
-		full_idea_group = quality_ideas
+		full_idea_group = broadside_ideas
 	}
 	
 	artillery_power = 0.1
@@ -83,16 +83,16 @@ the_tolerance_act = { # Lance of Righteousness Act
 
 	potential = {
 		has_idea_group = religious_ideas
-		has_idea_group = plutocracy_ideas
+		has_idea_group = charge_ideas
 		OR = {
 			full_idea_group = religious_ideas
-			full_idea_group = plutocracy_ideas
+			full_idea_group = charge_ideas
 		}
 	}
 	
 	allow = {
 		full_idea_group = religious_ideas
-		full_idea_group = plutocracy_ideas
+		full_idea_group = charge_ideas
 	}
 
 	tolerance_heretic = 3
@@ -169,16 +169,16 @@ the_provincial_taxation_system = {
 
 	potential = {
 		has_idea_group = administrative_ideas
-		has_idea_group = quantity_ideas
+		has_idea_group = boarding_ideas
 		OR = {
 			full_idea_group = administrative_ideas
-			full_idea_group = quantity_ideas
+			full_idea_group = boarding_ideas
 		}
 	}
 	
 	allow = {
 		full_idea_group = administrative_ideas
-		full_idea_group = quantity_ideas
+		full_idea_group = boarding_ideas
 	}
 	
 	num_accepted_cultures = 1
@@ -200,16 +200,16 @@ the_liquor_act = {
 	
 	
 	potential = {
-		has_idea_group = quality_ideas
+		has_idea_group = broadside_ideas
 		has_idea_group = administrative_ideas
 		OR = {
-			full_idea_group = quality_ideas
+			full_idea_group = broadside_ideas
 			full_idea_group = administrative_ideas
 		}
 	}
 	
 	allow = {
-		full_idea_group = quality_ideas
+		full_idea_group = broadside_ideas
 		full_idea_group = administrative_ideas
 	}	
 	
@@ -266,16 +266,16 @@ superior_supply_system = {
 	monarch_power = MIL
 	
 	potential = {
-		has_idea_group = quality_ideas
+		has_idea_group = broadside_ideas
 		has_idea_group = exploration_ideas
 		OR = {
-			full_idea_group = quality_ideas
+			full_idea_group = broadside_ideas
 			full_idea_group = exploration_ideas
 		}
 	}
 	
 	allow = {
-		full_idea_group = quality_ideas
+		full_idea_group = broadside_ideas
 		full_idea_group = exploration_ideas
 	}
 
@@ -351,16 +351,16 @@ modern_firearm_techniques = {
 	
 	potential = {
 		has_idea_group = innovativeness_ideas
-		has_idea_group = quality_ideas
+		has_idea_group = broadside_ideas
 		OR = {
 			full_idea_group = innovativeness_ideas
-			full_idea_group = quality_ideas
+			full_idea_group = broadside_ideas
 		}
 	}
 	
 	allow = {
 		full_idea_group = innovativeness_ideas
-		full_idea_group = quality_ideas
+		full_idea_group = broadside_ideas
 	}
 	
 	artillery_power = 0.1
@@ -388,16 +388,16 @@ great_recovery_act = {
 	
 	potential = {
 		has_idea_group = innovativeness_ideas
-		has_idea_group = quantity_ideas
+		has_idea_group = boarding_ideas
 		OR = {
 			full_idea_group = innovativeness_ideas
-			full_idea_group = quantity_ideas
+			full_idea_group = boarding_ideas
 		}
 	}
 	
 	allow = {
 		full_idea_group = innovativeness_ideas
-		full_idea_group = quantity_ideas
+		full_idea_group = boarding_ideas
 	}
 
 	ship_capture_chance = 0.2
@@ -412,16 +412,16 @@ military_zeal_act = {
 	monarch_power = MIL
 	
 	potential = {
-		has_idea_group = quality_ideas
+		has_idea_group = broadside_ideas
 		has_idea_group = religious_ideas
 		OR = {
-			full_idea_group = quality_ideas
+			full_idea_group = broadside_ideas
 			full_idea_group = religious_ideas
 		}
 	}
 	
 	allow = {
-		full_idea_group = quality_ideas
+		full_idea_group = broadside_ideas
 		full_idea_group = religious_ideas
 	}
 	
@@ -442,16 +442,16 @@ field_priests = {
 
 	potential = {
 		has_idea_group = religious_ideas
-		has_idea_group = quantity_ideas
+		has_idea_group = boarding_ideas
 		OR = {
 			full_idea_group = religious_ideas
-			full_idea_group = quantity_ideas
+			full_idea_group = boarding_ideas
 		}
 	}
 	
 	allow = {
 		full_idea_group = religious_ideas
-		full_idea_group = quantity_ideas
+		full_idea_group = boarding_ideas
 	}
 
 	naval_morale = 0.15
@@ -469,16 +469,16 @@ pen_rely_on_sword_act = {
 	monarch_power = MIL
 	potential = {
 		has_idea_group = diplomatic_ideas
-		has_idea_group = quantity_ideas
+		has_idea_group = boarding_ideas
 		OR = {
 			full_idea_group = diplomatic_ideas
-			full_idea_group = quantity_ideas
+			full_idea_group = boarding_ideas
 		}
 	}
 	
 	allow = {
 		full_idea_group = diplomatic_ideas
-		full_idea_group = quantity_ideas
+		full_idea_group = boarding_ideas
 	}
 	
 	allowed_marine_fraction = 0.1
@@ -568,16 +568,16 @@ the_smite_act = {
 hired_adventurers_act = {
 	monarch_power = MIL
 	potential = {
-		has_idea_group = quantity_ideas
+		has_idea_group = boarding_ideas
 		has_idea_group = exploration_ideas
 		OR = {
-			full_idea_group = quantity_ideas
+			full_idea_group = boarding_ideas
 			full_idea_group = exploration_ideas
 		}
 	}
 	
 	allow = {
-		full_idea_group = quantity_ideas
+		full_idea_group = boarding_ideas
 		full_idea_group = exploration_ideas
 	}
 
@@ -691,16 +691,16 @@ inspirational_leaders = {
 	
 	potential = {
 		has_idea_group = humanist_ideas
-		has_idea_group = quantity_ideas
+		has_idea_group = boarding_ideas
 		OR = {
 			full_idea_group = humanist_ideas
-			full_idea_group = quantity_ideas
+			full_idea_group = boarding_ideas
 		}
 	}
 	
 	allow = {
 		full_idea_group = humanist_ideas
-		full_idea_group = quantity_ideas
+		full_idea_group = boarding_ideas
 	}	
 	
 	global_ship_recruit_speed = -0.2
@@ -774,16 +774,16 @@ elite_regiments_act = {
 	
 	potential = {
 		has_idea_group = influence_ideas
-		has_idea_group = quantity_ideas
+		has_idea_group = boarding_ideas
 		OR = {
 			full_idea_group = influence_ideas
-			full_idea_group = quantity_ideas
+			full_idea_group = boarding_ideas
 		}
 	}
 	
 	allow = {
 		full_idea_group = influence_ideas
-		full_idea_group = quantity_ideas
+		full_idea_group = boarding_ideas
 	}	
 
 	dip_advisor_cost = -0.25
@@ -799,16 +799,16 @@ light_cavalry_doctrine = {
 	
 	potential = {
 		has_idea_group = influence_ideas
-		has_idea_group = quality_ideas
+		has_idea_group = broadside_ideas
 		OR = {
 			full_idea_group = influence_ideas
-			full_idea_group = quality_ideas
+			full_idea_group = broadside_ideas
 		}
 	}
 	
 	allow = {
 		full_idea_group = influence_ideas
-		full_idea_group = quality_ideas
+		full_idea_group = broadside_ideas
 	}	
 	
 	heavy_ship_cost = -0.1
@@ -844,16 +844,16 @@ danger_close_policy = {
 	
 	potential = {
 		has_idea_group = humanist_ideas
-		has_idea_group = spy_ideas
+		has_idea_group = campaign_ideas
 		OR = {
 			full_idea_group = humanist_ideas
-			full_idea_group = spy_ideas
+			full_idea_group = campaign_ideas
 		}
 	}
 	
 	allow = {
 		full_idea_group = humanist_ideas
-		full_idea_group = spy_ideas
+		full_idea_group = campaign_ideas
 	}	
 	
 	manpower_recovery_speed = 0.2
@@ -888,12 +888,12 @@ weaponize_church_zeal_act = {
 	monarch_power = MIL
 	
 	potential = {
-		has_idea_group = spy_ideas
+		has_idea_group = campaign_ideas
 		has_idea_group = religious_ideas
 	}
 	
 	allow = {
-		full_idea_group = spy_ideas
+		full_idea_group = campaign_ideas
 		full_idea_group = religious_ideas
 	}
 

--- a/common/policies/Divine.txt
+++ b/common/policies/Divine.txt
@@ -44,12 +44,12 @@ maritime_scribes = {
 	
 	potential = {
 		has_idea_group = theocracy_gov_ideas
-		has_idea_group = maritime_ideas
+		has_idea_group = prestige_ideas
 	}
 	
 	allow = {
 		full_idea_group = theocracy_gov_ideas
-		full_idea_group = maritime_ideas
+		full_idea_group = prestige_ideas
 	}
 	
 	prestige_from_land_battles = 0.5

--- a/common/policies/Jurisprudence.txt
+++ b/common/policies/Jurisprudence.txt
@@ -4,15 +4,15 @@ supply_train_act = {
 
 	potential = {
 		has_idea_group = jurisprudence_ideas
-		has_idea_group = quality_ideas
+		has_idea_group = broadside_ideas
 		OR = {
 			full_idea_group = jurisprudence_ideas
-			full_idea_group = quality_ideas
+			full_idea_group = broadside_ideas
 		}	
 	}
 	allow = {
 		full_idea_group = jurisprudence_ideas
-		full_idea_group = quality_ideas
+		full_idea_group = broadside_ideas
 	}
 	
 	province_warscore_cost = -0.15
@@ -56,16 +56,16 @@ colonial_garrisons = {
 
 
 	potential = {
-		has_idea_group = quantity_ideas
+		has_idea_group = boarding_ideas
 		has_idea_group = jurisprudence_ideas
 		OR = {
-			full_idea_group = quantity_ideas
+			full_idea_group = boarding_ideas
 			full_idea_group = jurisprudence_ideas
 		}
 	}
 	
 	allow = {
-		full_idea_group = quantity_ideas
+		full_idea_group = boarding_ideas
 		full_idea_group = jurisprudence_ideas
 	}
 
@@ -193,16 +193,16 @@ taxation_with_representation = {
 new_order_act = {
 	monarch_power = ADM
 	potential = {
-		has_idea_group = spy_ideas
+		has_idea_group = campaign_ideas
 		has_idea_group = jurisprudence_ideas
 		OR = {
-			full_idea_group = spy_ideas
+			full_idea_group = campaign_ideas
 			full_idea_group = jurisprudence_ideas
 		}
 	}
 	
 	allow = {
-		full_idea_group = spy_ideas
+		full_idea_group = campaign_ideas
 		full_idea_group = jurisprudence_ideas
 	}
 	

--- a/common/policies/OceanTrade.txt
+++ b/common/policies/OceanTrade.txt
@@ -278,12 +278,12 @@ northern_school_act = {
 	
 	potential = {
 		has_idea_group = naval_ideas
-		has_idea_group = quality_ideas
+		has_idea_group = broadside_ideas
 	}
 	
 	allow = {
 		full_idea_group = naval_ideas
-		full_idea_group = quality_ideas
+		full_idea_group = broadside_ideas
 	}
 	
 	naval_morale = 0.05
@@ -303,12 +303,12 @@ eastern_school_act = {
 	
 	potential = {
 		has_idea_group = naval_ideas
-		has_idea_group = quantity_ideas
+		has_idea_group = boarding_ideas
 	}
 	
 	allow = {
 		full_idea_group = naval_ideas
-		full_idea_group = quantity_ideas
+		full_idea_group = boarding_ideas
 	}
 
 	naval_forcelimit_modifier = 0.3
@@ -325,16 +325,16 @@ planned_lanes_of_fire_act = {
 	
 	potential = {
 		has_idea_group = naval_ideas
-		has_idea_group = spy_ideas
+		has_idea_group = campaign_ideas
 		OR = {
 			full_idea_group = naval_ideas
-			full_idea_group = spy_ideas
+			full_idea_group = campaign_ideas
 		}
 	}
 	
 	allow = {
 		full_idea_group = naval_ideas
-		full_idea_group = spy_ideas
+		full_idea_group = campaign_ideas
 	}
 	
 	siege_blockade_progress = 2

--- a/common/policies/Prestige.txt
+++ b/common/policies/Prestige.txt
@@ -3,16 +3,16 @@ notable_academies_act = {
 	monarch_power = ADM
 	
 	potential = {
-		has_idea_group = maritime_ideas
+		has_idea_group = prestige_ideas
 		has_idea_group = innovativeness_ideas
 		OR = {
-			full_idea_group = maritime_ideas
+			full_idea_group = prestige_ideas
 			full_idea_group = innovativeness_ideas
 		}
 	}
 	
 	allow = {
-		full_idea_group = maritime_ideas
+		full_idea_group = prestige_ideas
 		full_idea_group = innovativeness_ideas
 	}
 	
@@ -33,16 +33,16 @@ good_news_act = {
 	monarch_power = ADM
 	
 	potential = {
-		has_idea_group = maritime_ideas
+		has_idea_group = prestige_ideas
 		has_idea_group = religious_ideas
 		OR = {
-			full_idea_group = maritime_ideas
+			full_idea_group = prestige_ideas
 			full_idea_group = religious_ideas
 		}
 	}
 	
 	allow = {
-		full_idea_group = maritime_ideas
+		full_idea_group = prestige_ideas
 		full_idea_group = religious_ideas
 	}
 	
@@ -59,16 +59,16 @@ paid_promotion_act = {
 	monarch_power = DIP
 	
 	potential = {
-		has_idea_group = maritime_ideas
+		has_idea_group = prestige_ideas
 		has_idea_group = economic_ideas
 		OR = {
-			full_idea_group = maritime_ideas
+			full_idea_group = prestige_ideas
 			full_idea_group = economic_ideas
 		}
 	}
 	
 	allow = {
-		full_idea_group = maritime_ideas
+		full_idea_group = prestige_ideas
 		full_idea_group = economic_ideas
 	}
 	
@@ -85,16 +85,16 @@ honorable_rogues_act = {
 	monarch_power = ADM
 	
 	potential = {
-		has_idea_group = maritime_ideas
+		has_idea_group = prestige_ideas
 		has_idea_group = administrative_ideas
 		OR = {
-			full_idea_group = maritime_ideas
+			full_idea_group = prestige_ideas
 			full_idea_group = administrative_ideas
 		}
 	}
 	
 	allow = {
-		full_idea_group = maritime_ideas
+		full_idea_group = prestige_ideas
 		full_idea_group = administrative_ideas
 	}
 	
@@ -114,16 +114,16 @@ national_business_act = {
 	monarch_power = DIP
 	
 	potential = {
-		has_idea_group = maritime_ideas
+		has_idea_group = prestige_ideas
 		has_idea_group = humanist_ideas
 		OR = {
-			full_idea_group = maritime_ideas
+			full_idea_group = prestige_ideas
 			full_idea_group = humanist_ideas
 		}
 	}
 	
 	allow = {
-		full_idea_group = maritime_ideas
+		full_idea_group = prestige_ideas
 		full_idea_group = humanist_ideas
 	}
 	
@@ -140,16 +140,16 @@ nationalized_laws_act = {
 	monarch_power = ADM
 	
 	potential = {
-		has_idea_group = maritime_ideas
+		has_idea_group = prestige_ideas
 		has_idea_group = jurisprudence_ideas
 		OR = {
-			full_idea_group = maritime_ideas
+			full_idea_group = prestige_ideas
 			full_idea_group = jurisprudence_ideas
 		}
 	}
 	
 	allow = {
-		full_idea_group = maritime_ideas
+		full_idea_group = prestige_ideas
 		full_idea_group = jurisprudence_ideas
 	}
 	
@@ -170,16 +170,16 @@ glorious_cavalry_act = {
 	monarch_power = DIP
 	
 	potential = {
-		has_idea_group = maritime_ideas
+		has_idea_group = prestige_ideas
 		has_idea_group = aristocracy_ideas
 		OR = {
-			full_idea_group = maritime_ideas
+			full_idea_group = prestige_ideas
 			full_idea_group = aristocracy_ideas
 		}
 	}
 	
 	allow = {
-		full_idea_group = maritime_ideas
+		full_idea_group = prestige_ideas
 		full_idea_group = aristocracy_ideas
 	}
 	
@@ -196,16 +196,16 @@ land_of_plenty_act = {
 	monarch_power = DIP
 	
 	potential = {
-		has_idea_group = maritime_ideas
+		has_idea_group = prestige_ideas
 		has_idea_group = plutocracy_ideas
 		OR = {
-			full_idea_group = maritime_ideas
+			full_idea_group = prestige_ideas
 			full_idea_group = plutocracy_ideas
 		}
 	}
 	
 	allow = {
-		full_idea_group = maritime_ideas
+		full_idea_group = prestige_ideas
 		full_idea_group = plutocracy_ideas
 	}
 	
@@ -222,16 +222,16 @@ khan_of_the_hill_act = {
 	monarch_power = DIP
 	
 	potential = {
-		has_idea_group = maritime_ideas
+		has_idea_group = prestige_ideas
 		has_idea_group = horde_gov_ideas
 		OR = {
-			full_idea_group = maritime_ideas
+			full_idea_group = prestige_ideas
 			full_idea_group = horde_gov_ideas
 		}
 	}
 	
 	allow = {
-		full_idea_group = maritime_ideas
+		full_idea_group = prestige_ideas
 		full_idea_group = horde_gov_ideas
 	}
 
@@ -248,16 +248,16 @@ call_to_glory_act = {
 	monarch_power = DIP
 	
 	potential = {
-		has_idea_group = maritime_ideas
+		has_idea_group = prestige_ideas
 		has_idea_group = offensive_ideas
 		OR = {
-			full_idea_group = maritime_ideas
+			full_idea_group = prestige_ideas
 			full_idea_group = offensive_ideas
 		}
 	}
 	
 	allow = {
-		full_idea_group = maritime_ideas
+		full_idea_group = prestige_ideas
 		full_idea_group = offensive_ideas
 	}
 	
@@ -278,16 +278,16 @@ defense_of_the_homeland_act = {
 	monarch_power = MIL
 	
 	potential = {
-		has_idea_group = maritime_ideas
+		has_idea_group = prestige_ideas
 		has_idea_group = defensive_ideas
 		OR = {
-			full_idea_group = maritime_ideas
+			full_idea_group = prestige_ideas
 			full_idea_group = defensive_ideas
 		}
 	}
 	
 	allow = {
-		full_idea_group = maritime_ideas
+		full_idea_group = prestige_ideas
 		full_idea_group = defensive_ideas
 	}
 	
@@ -308,17 +308,17 @@ best_of_the_best_act = {
 	monarch_power = MIL
 	
 	potential = {
-		has_idea_group = maritime_ideas
-		has_idea_group = quality_ideas
+		has_idea_group = prestige_ideas
+		has_idea_group = broadside_ideas
 		OR = {
-			full_idea_group = maritime_ideas
-			full_idea_group = quality_ideas
+			full_idea_group = prestige_ideas
+			full_idea_group = broadside_ideas
 		}
 	}
 	
 	allow = {
-		full_idea_group = maritime_ideas
-		full_idea_group = quality_ideas
+		full_idea_group = prestige_ideas
+		full_idea_group = broadside_ideas
 	}
 	
 	leader_naval_fire = 1
@@ -334,17 +334,17 @@ flock_to_the_banners_act = {
 	monarch_power = MIL
 	
 	potential = {
-		has_idea_group = maritime_ideas
-		has_idea_group = quantity_ideas
+		has_idea_group = prestige_ideas
+		has_idea_group = boarding_ideas
 		OR = {
-			full_idea_group = maritime_ideas
-			full_idea_group = quantity_ideas
+			full_idea_group = prestige_ideas
+			full_idea_group = boarding_ideas
 		}
 	}
 	
 	allow = {
-		full_idea_group = maritime_ideas
-		full_idea_group = quantity_ideas
+		full_idea_group = prestige_ideas
+		full_idea_group = boarding_ideas
 	}
 
 	sailors_recovery_speed = 0.2
@@ -360,17 +360,17 @@ state_propaganda_act = {
 	monarch_power = MIL
 	
 	potential = {
-		has_idea_group = maritime_ideas
-		has_idea_group = spy_ideas
+		has_idea_group = prestige_ideas
+		has_idea_group = campaign_ideas
 		OR = {
-			full_idea_group = maritime_ideas
-			full_idea_group = spy_ideas
+			full_idea_group = prestige_ideas
+			full_idea_group = campaign_ideas
 		}
 	}
 	
 	allow = {
-		full_idea_group = maritime_ideas
-		full_idea_group = spy_ideas
+		full_idea_group = prestige_ideas
+		full_idea_group = campaign_ideas
 	}
 	
 	global_manpower_modifier = 0.15


### PR DESCRIPTION
- Updated policies to new naming convention (e.g. `maritime_ideas` -> `prestige_ideas`).